### PR TITLE
Update icon url

### DIFF
--- a/arm2pulumi/arm2pulumi.nuspec
+++ b/arm2pulumi/arm2pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>arm2pulumi</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2020</copyright>
     <tags>pulumi arm2pulumi azure</tags>
     <releaseNotes>https://github.com/pulumi/pulumi-azure-native/</releaseNotes>

--- a/cf2pulumi/cfn2pulumi.nuspec
+++ b/cf2pulumi/cfn2pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>cf2pulumi</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2020</copyright>
     <tags>pulumi cf2pulumi kubernetes</tags>
     <releaseNotes>https://github.com/pulumi/pulumi-aws-native/</releaseNotes>

--- a/crd2pulumi/crd2pulumi.nuspec
+++ b/crd2pulumi/crd2pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>crd2pulumi</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2020</copyright>
     <tags>pulumi crd2pulumi kubernetes</tags>
     <releaseNotes>https://github.com/pulumi/crd2pulumi/</releaseNotes>

--- a/kube2pulumi/kube2pulumi.nuspec
+++ b/kube2pulumi/kube2pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>kube2pulumi</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2020</copyright>
     <tags>pulumi kube2pulumi kubernetes</tags>
     <releaseNotes>https://github.com/pulumi/kube2pulumi/</releaseNotes>

--- a/pulumi/pulumi.nuspec
+++ b/pulumi/pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>Pulumi (Portable)</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2021</copyright>
     <tags>pulumi sdk</tags>
     <releaseNotes>https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md</releaseNotes>

--- a/tf2pulumi/tf2pulumi.nuspec
+++ b/tf2pulumi/tf2pulumi.nuspec
@@ -7,7 +7,7 @@
     <title>tf2pulumi</title>
     <authors>Pulumi</authors>
     <projectUrl>https://www.pulumi.com</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi/master/sdk/dotnet/pulumi_logo_64x64.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/pulumi/pulumi-dotnet/main/sdk/pulumi_logo_64x64.png</iconUrl>
     <copyright>Pulumi 2016-2020</copyright>
     <tags>pulumi tf2pulumi</tags>
     <releaseNotes>https://github.com/pulumi/tf2pulumi/</releaseNotes>


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-chocolatey/issues/8

I did ponder if maybe the logo should be in /pulumi rather than /pulumi-dotnet.
Kinda surprised but out of all the package systems we use it seems only nuget/chocolatey has support for package icons.
Just if we do move the icon around try to remember these URLs will need fixing again.