### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/deploy-crd2pulumi.yml
+++ b/.github/workflows/deploy-crd2pulumi.yml
@@ -1,6 +1,11 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
   VERSION: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: CHOCO_API_KEY
 
 on:
   repository_dispatch:
@@ -11,6 +16,9 @@ jobs:
     name: Deploy Chocolatey Package for crd2pulumi
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Push Choco

--- a/.github/workflows/deploy-kube2pulumi.yml
+++ b/.github/workflows/deploy-kube2pulumi.yml
@@ -1,6 +1,11 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
   VERSION: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: CHOCO_API_KEY
 
 on:
   repository_dispatch:
@@ -11,6 +16,9 @@ jobs:
     name: Deploy Chocolatey Package for kube2pulumi
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Push Choco

--- a/.github/workflows/deploy-pulumictl.yml
+++ b/.github/workflows/deploy-pulumictl.yml
@@ -1,6 +1,11 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
   VERSION: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: CHOCO_API_KEY
 
 on:
   repository_dispatch:
@@ -11,6 +16,9 @@ jobs:
     name: Deploy Chocolatey Package for pulumictl
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Push Choco

--- a/.github/workflows/deploy-tf2pulumi.yml
+++ b/.github/workflows/deploy-tf2pulumi.yml
@@ -1,6 +1,11 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
   VERSION: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: CHOCO_API_KEY
 
 on:
   repository_dispatch:
@@ -11,6 +16,9 @@ jobs:
     name: Deploy Chocolatey Package for tf2pulumi
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Push Choco

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
   VERSION: ${{ github.event.client_payload.ref }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: CHOCO_API_KEY
 
 on:
   repository_dispatch:
@@ -11,6 +16,9 @@ jobs:
     name: Deploy Chocolatey Package
     runs-on: windows-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Push Choco


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
